### PR TITLE
Use standard 'success and 'error faces

### DIFF
--- a/runtests.el
+++ b/runtests.el
@@ -31,10 +31,10 @@ If the script fails the output of the script will be shown with ansi colors.")
   :type '(string :tag "command"))
 
 (defun runtests-notify-error ()
-  (message (propertize "Tests failed" 'face '(:foreground "red" :weight extra-bold))))
+  (message (propertize "Tests failed" 'face 'error)))
 
 (defun runtests-notify-success ()
-  (message (propertize "Tests passed" 'face '(:foreground "green" :weight extra-bold))))
+  (message (propertize "Tests passed" 'face 'success)))
 
 (defun runtests-ansi-color-filter (process output)
   (when (buffer-live-p (process-buffer process))


### PR DESCRIPTION
"red" and "green" foregrounds will only display well with a subset of all possible themes, whereas the built-in "success" and "error" faces will generally be overridden by themes. It's preferable, then, to use those standard faces.

(If you wanted to allow customisation, you would use `defface` to declare two faces called `runtests-minibuffer-error` and `runtests-minibuffer-success`, each of which would be defined to `:inherit` the `error` and `success` faces respectively.)

In connection with https://github.com/milkypostman/melpa/pull/2992
